### PR TITLE
Add toml.d.ts to files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "README.md",
     "dist/toml-browser.js",
     "lib",
-    "toml.js"
+    "toml.js",
+    "toml.d.ts"
   ],
   "keywords": [
     "toml",


### PR DESCRIPTION
Types don't work correctly since the type definition is not included in the npm bundle. This fixes the problem.

As a workaround, in the meantime we can do:
```sh
cd node_modules/toml-j0.4 && wget https://raw.githubusercontent.com/jakwings/toml-j0.4/v1.1.1/toml.d.ts
```